### PR TITLE
Add nettle-bin and postgresql to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN \
         traceroute \
         tcptraceroute \
         whois \
+        postgresql-client \
+        nettle-bin \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Sonar should use the latest stable non-LTS release:


- The lastest non-LTS Sonar release is using a new hash algorithm: "PBKDF2"
- "postgresql" is needed for running psql commands

Useful:
- Non-LTS vs LTS -> [here](https://www.sonarqube.org/downloads/lts/)
- Release Upgrade Notes -> [here](https://docs.sonarqube.org/latest/setup/upgrade-notes/)